### PR TITLE
Changed API to create .env files from Ansible vars instead of static files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Ansible role to Transfer a Dotenv File
+# Ansible role to create a .env file
 
 [![Build Status](https://circleci.com/gh/crushlovely/ansible-dotenv.svg?style=shield)](https://github.com/crushlovely/ansible-dotenv)
 [![Current Version](http://img.shields.io/github/release/crushlovely/ansible-dotenv.svg?style=flat)](https://galaxy.ansible.com/list#/roles/2454)
 
-This Ansible role transfers dotenv files to servers running an application.
+This Ansible role creates a [.env](https://github.com/bkeepers/dotenv) file on your servers based on variables you define in your playbook vars.
 
 ## Installation
 
@@ -14,20 +14,13 @@ $ ansible-galaxy install crushlovely.dotenv,v1.0.0
 ## Variables
 
 ``` yaml
-server_env:
-app_path:
-app:
-  user:
-  group:
-```
-You can also add a vars folder to your project folder and have your variables served by adding them to a file and calling it in your playbook.
-
-```yaml
-- hosts: localhost
-...
-  vars_files:
-    - vars/default_vars.yml
-...
+dotenv:
+  path: "/path/to/your/file" # The folder where your .env will be stored on the server.
+  user: "username" # The username of the user assigned permission to the .env file.
+  group: "groupname" # The group name of the group assigned permission to the .env file.
+  vars:
+    rails_env: production
+    api_token: s3cr3tt0k3n
 ```
 
 ## Usage
@@ -38,6 +31,13 @@ Once this role is installed on your system, include it in the roles list of your
 - hosts: localhost
   roles:
     - crushlovely.dotenv
+```
+
+The example YAML above will be transformed into a standard `.env` file like so:
+
+```bash
+RAILS_ENV=production
+API_TOKEN=s3cr3tt0k3n
 ```
 
 ## Dependencies

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
 test:
   override:
     # Get nginx role
-    - ansible-galaxy install -f https://github.com/crushlovely/ansible-dotenv.git,remotes/origin/$CIRCLE_BRANCH -p ./tests/roles/
+    - ansible-galaxy install -f https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git,remotes/origin/$CIRCLE_BRANCH -p ./tests/
 
     # Check the role/playbook's syntax.
     - ansible-playbook --syntax-check -i tests/inventory tests/test.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-server_env: qa
-app_path: /home/ubuntu/test
-app:
-  user: ubuntu
-  group: ubuntu
+dotenv:
+  path: ""
+  user: ""
+  group: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Base | Copy .env to shared location
-  file: path={{ app_path }}/shared/ owner={{ app.user }} group={{ app.user }} state=directory
+- name: Ensure the directory for .env exists
+  file: path={{ dotenv.path }} owner={{ dotenv.user }} group={{ dotenv.group }} state=directory
 
-- name: Base | Copy .env to shared location
-  copy: src=files/.env.{{ server_env }} dest={{ app_path }}/shared/.env owner={{ app.user }} group={{ app.user }} force=yes backup=yes
+- name: Create or update .env file
+  template: src=dotenv.j2 dest={{ dotenv.path }}/.env owner={{ dotenv.user }} group={{ dotenv.group }} backup=yes

--- a/templates/dotenv.j2
+++ b/templates/dotenv.j2
@@ -1,0 +1,5 @@
+{% if dotenv.vars %}
+{% for key, value in dotenv.vars|dictsort %}
+{{ key.upper() }}={{ value }}
+{% endfor %}
+{% endif %}

--- a/tests/files/.env.qa
+++ b/tests/files/.env.qa
@@ -1,1 +1,0 @@
-SERVER_ENV=QA

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,5 +3,12 @@
   connection: local
   remote_user: ubuntu
   gather_facts: false
+  vars:
+    dotenv:
+      path: "/home/ubuntu/test"
+      user: "ubuntu"
+      group: "ubuntu"
+      vars:
+        rails_env: "production"
   roles:
     - ansible-dotenv


### PR DESCRIPTION
**Note**: This is a backwards-incompatible change.
- Moved definition of .env content into vars instead of a static file. This allows for more seamless integration with Ansible Vault which can be used to encrypt sensitive data that is commonly found in .env files.
- Namespaced all variables used in the role so they don't depend on custom naming we were using previously.
